### PR TITLE
Add Passport y autenticación de token

### DIFF
--- a/Backend/src/app.ts
+++ b/Backend/src/app.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import morgan from 'morgan';
 import cors, { CorsOptions } from 'cors';
 import dotenv from 'dotenv';
+import passport from 'passport';
+import passportMiddleware from './middlewares/passport'
 
 // Load enviroments variables
 dotenv.config();
@@ -24,6 +26,8 @@ app.use(morgan('dev'));
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 app.use(cors(corsConfig));
+app.use(passport.initialize());
+passport.use(passportMiddleware);
 
 // Routes
 app.use(indexRoutes);

--- a/Backend/src/config/config.ts
+++ b/Backend/src/config/config.ts
@@ -1,0 +1,3 @@
+export default {
+    jwtSecret: process.env.JWT_SECRET || 'somesecrettoken',
+}

--- a/Backend/src/middlewares/jwt.ts
+++ b/Backend/src/middlewares/jwt.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
+import config from '../config/config';
 
 dotenv.config();
 
@@ -9,7 +10,7 @@ dotenv.config();
  * @returns token del usuario
  */
 export function signToken(id: any) {
-	const token = jwt.sign({ _id: id }, process.env.TOKEN_SECRET || 'secret_key', {
+	const token = jwt.sign({ _id: id }, config.jwtSecret, {
 		expiresIn: 86400
 	});
 

--- a/Backend/src/middlewares/passport.ts
+++ b/Backend/src/middlewares/passport.ts
@@ -1,0 +1,22 @@
+import { Strategy, ExtractJwt, StrategyOptions } from "passport-jwt";
+import config from '../config/config';
+import User from '../routes/User/user.model'
+
+const opts: StrategyOptions = {
+    jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+    secretOrKey: config.jwtSecret
+};
+
+export default new Strategy(opts, async (payload, done) => {
+    try {
+        const user = await User.findById(payload._id);
+
+        if ( user ){
+            return done(null, user);
+        }
+        return done(null,false);
+
+    } catch (error) {
+        console.log(error);
+    }
+});

--- a/Backend/src/middlewares/passport.ts
+++ b/Backend/src/middlewares/passport.ts
@@ -7,6 +7,10 @@ const opts: StrategyOptions = {
     secretOrKey: config.jwtSecret
 };
 
+/** 
+ * Se encarga de validar el _id que viene dentro del token con los ids registrados en la BD.
+ * @returns null para el error, user (si existe) || null (si no existe)
+ */
 export default new Strategy(opts, async (payload, done) => {
     try {
         const user = await User.findById(payload._id);

--- a/Backend/src/routes/User/user.controller.ts
+++ b/Backend/src/routes/User/user.controller.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from "express";
 import User, { IUser } from './user.model';
-import { signToken } from "../jwt";
+import { signToken } from "../../middlewares/jwt";
 
 /**
  * Funcion que maneja la petición de agregar un nuevo usuario al sistema

--- a/Backend/src/routes/User/user.routes.ts
+++ b/Backend/src/routes/User/user.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import * as userCtrl from './user.controller';
+import passport from 'passport';
 
 const router = Router();
 
@@ -14,5 +15,11 @@ router.post( '/user/signin', userCtrl.signIn );
 // Modificar un usuario
 
 // Eliminar un usuario
+
+
+//Ruta de prueba passport (para probar el acceso via token)
+router.get('/special', passport.authenticate('jwt', {session: false}), (req, res) => {
+    res.send('Succes');
+});
 
 export default router;

--- a/Backend/src/routes/jwt.ts
+++ b/Backend/src/routes/jwt.ts
@@ -9,7 +9,9 @@ dotenv.config();
  * @returns token del usuario
  */
 export function signToken(id: any) {
-	const token = jwt.sign({ _id: id }, process.env.TOKEN_SECRET || 'secret_key');
+	const token = jwt.sign({ _id: id }, process.env.TOKEN_SECRET || 'secret_key', {
+		expiresIn: 86400
+	});
 
 	return token;
 }


### PR DESCRIPTION
Se agrega passport para la validación de los tokens enviados en el header.

Ejemplo funcional: 
- Se inicia sesión obteniendo el token:
![imagen](https://user-images.githubusercontent.com/39105967/147996748-d80d5fc7-2e76-41ee-b0fc-03ea091dac46.png)
- Posteriormente es enviado en el authorization a la ruta de prueba.
![imagen](https://user-images.githubusercontent.com/39105967/147996812-aa70b88a-3dbe-4450-b1d7-3542d2bc180b.png)
Arrojando que el token es correcto y logra entrar a la ruta.

- De manera contraria, al no enviar token:
![imagen](https://user-images.githubusercontent.com/39105967/147996933-ef76a385-f872-417b-b3d2-104569583278.png)
Indica que no está autorizado y no ingresa a la ruta.

- Al enviar un token no válido:
![imagen](https://user-images.githubusercontent.com/39105967/147997013-2f1b1025-70bd-4bf5-b2cf-94bab6e1d4c0.png)
También indica que no está autorizado y no permite el acceso.


PD: Decidí mantener la ruta de prueba en el Pr para un posterior uso y prueba desde el Front. Una vez realizado y validando su correcto funcionamiento será eliminada.