### PR TITLE
Get sensor alerts

### DIFF
--- a/Backend/src/routes/Alert/alert.routes.ts
+++ b/Backend/src/routes/Alert/alert.routes.ts
@@ -10,4 +10,7 @@ router.get('/alert/recent/:id_company', alertCtrl.recentAlerts);
 // Obtener la cantidad de alertas de esta semana y un porcentaje asociado a la semana anterior
 router.get('/alert/quantity/:id_company', alertCtrl.quantityAlerts);
 
+//Obtener las alertas asociadas a un sensor
+router.get('/alert/:id_sensor', alertCtrl.sensorAlerts);
+
 export default router;


### PR DESCRIPTION
Se completa el endpoint que obtiene las alertas asociadas a un sensor. 

Recibe un id_sensor por params en la ruta http://localhost:4000/alert/:id_sensor. Y retorna lo siguiente:
![imagen](https://user-images.githubusercontent.com/39105967/153425386-07c447bd-aeb2-4266-9766-fa604816a4a5.png)
