### PR TITLE
ADD: Exponential alerts

### DIFF
--- a/Backend/src/routes/Alert/alert.controller.ts
+++ b/Backend/src/routes/Alert/alert.controller.ts
@@ -45,6 +45,11 @@ export async function createAlert( reading:any, sensor:any ){
     const last_alert = new Date();
     await Sensor.findByIdAndUpdate( sensor._id ,{ "last_alert": last_alert });
 
+    //se actualiza el alert_time a exponencial si está definido por default
+    if ( !sensor.custom_alert ){
+        await Sensor.findByIdAndUpdate(sensor._id, {"alert_time": sensor.alert_time * 2});
+    }
+
     //se envía el correo con la alerta a la compañia
     sendEmailAlert(companyFound, stationFound, sensor, alertSaved);
 }

--- a/Backend/src/routes/Sensor/sensor.controller.ts
+++ b/Backend/src/routes/Sensor/sensor.controller.ts
@@ -363,10 +363,11 @@ export const sensorsON: RequestHandler = async (req, res) => {
 }
 
 /**
- * Función encargada de obtener la cantidad total de sensores y los sensores activos de ese total
- * @route Put '/panel/sensors/:id_company'
- * @param req Request de la petición, se espera que tenga el id de la compañia
- * @param res Response, retorna un object con succes: true, data: { }, message: "String" de los sensores de la compañia
+ * Función encargada modificar el valor de custom_alert reiniciandolo al tiempo de alertas por default (30min) y 
+ * apagando (cambiando a false) la variable custom_alert del sensor
+ * @route Put '/sensor/custom_alert/:id'
+ * @param req Request de la petición, se espera que tenga el id del sensor
+ * @param res Response, retorna un object con succes: true, data: { }, message: "String" del custom_alert si todo sale bien
  */
 export const customAlertTime: RequestHandler = async (req, res) => {
     const _idSensor = req.params.id;

--- a/Backend/src/routes/Sensor/sensor.controller.ts
+++ b/Backend/src/routes/Sensor/sensor.controller.ts
@@ -327,7 +327,10 @@ export const updateAlertTime: RequestHandler = async (req, res) => {
   
     //se actualiza el alert_time desde la BD
     await Sensor.findByIdAndUpdate( _idSensor, { "alert_time": alert_time });
-    
+
+    //se actualiza la variable alerta personalizada en el sensor
+    await Sensor.findByIdAndUpdate( _idSensor, { "custom_alert": true });
+
     return res.status(200).send( { success: true, data:{}, message: 'Alert_time actualizado de manera correcta.'});
 }
 
@@ -357,4 +360,32 @@ export const sensorsON: RequestHandler = async (req, res) => {
         quantitySensors: quantitySensorsCompany,
         quantitySensorsON: quantitySensorsCompanyON
     }, message: 'Cantidad de sensores encontrados con éxito'});
+}
+
+/**
+ * Función encargada de obtener la cantidad total de sensores y los sensores activos de ese total
+ * @route Put '/panel/sensors/:id_company'
+ * @param req Request de la petición, se espera que tenga el id de la compañia
+ * @param res Response, retorna un object con succes: true, data: { }, message: "String" de los sensores de la compañia
+ */
+export const customAlertTime: RequestHandler = async (req, res) => {
+    const _idSensor = req.params.id;
+
+    //se valida el _id ingresado del sensor
+    if ( !Types.ObjectId.isValid( _idSensor ) )
+    return res.status(400).send({ success: false, data:{}, message: 'ERROR: El id ingresado no es válido.' });
+
+    const sensorFound = await Sensor.findById( _idSensor );
+
+    //se valida la existencia del sensor en el sistema
+    if ( !sensorFound )
+        return res.status(404).send({ success: false, data:{}, message: 'ERROR: El sensor ingresado no existe en el sistema.' });
+
+    //se actualiza el valor de custom_alert desde la BD
+    await Sensor.findByIdAndUpdate(_idSensor, {"custom_alert": false});
+
+    //se actualiza el alert_time al valor por default (30min)
+    await Sensor.findByIdAndUpdate(_idSensor, {"alert_time": 30});
+
+    return res.status(200).send( { success: true, data:{}, message: 'Custom_alert actualizada de manera correcta.'});
 }

--- a/Backend/src/routes/Sensor/sensor.model.ts
+++ b/Backend/src/routes/Sensor/sensor.model.ts
@@ -35,6 +35,10 @@ const sensorSchema = new Schema({
         type: Date,
         default: null
     },
+    custom_alert: {
+        type: Boolean,
+        default: false
+    },
     token_reading: {
         type: String,
         default: null,

--- a/Backend/src/routes/Sensor/sensor.routes.ts
+++ b/Backend/src/routes/Sensor/sensor.routes.ts
@@ -27,4 +27,7 @@ router.put('/sensor/alert_time/:id', sensorCtrl.updateAlertTime);
 // Obtener sensores activos 
 router.get('/panel/sensors/:id_company', sensorCtrl.sensorsON);
 
+// Modificar el valor de custom_alert (apagándolo)
+router.put('/sensor/custom_alert/:id', sensorCtrl.customAlertTime);
+
 export default router;


### PR DESCRIPTION
Se agrega la exponencialidad al tiempo de las alertas (alert_time), estas solamente aumentan cuando esta habilitada la configuración por default (30min) y el custom_alert = false. En caso contrario, cuando el alert_time es modificado a través del endpoint updateAlertTime, el custom_alert se cambia a true y la exponencialidad no se aplica. 
Para poder volver a los valores por default, se debe mandar el id del sensor por params a la ruta http://localhost:4000/sensor/custom_alert/:id . Esta ruta vuelve el alert_time = 30 y custom-alert = false. Aplicando nuevamente la exponencialidad. 

Segun lo que me comentaba Ignacio; se debe poner en el front un campo de ✅  que sea “activar modificacion de lapsus de notificacion personalizado” o algo asi y si esta activo tome en cuenta y permita poner un valor personalizado. De no ser asi que tome por default el tema exponencial.  Siendo desde 30min  - 1hr - 2hr - 4hr ....