### PR TITLE
ADD: Se agrega el endpoint companyReadings

### DIFF
--- a/Backend/src/routes/Alert/alert.controller.ts
+++ b/Backend/src/routes/Alert/alert.controller.ts
@@ -116,8 +116,8 @@ export const quantityAlerts: RequestHandler = async (req, res) => {
     const date = new Date(); //fecha actual
 
     //se definen los tiempos de inicio de la semana actual y la anterior + las 3 hrs de la zona horaria
-    const current_week = new Date( date.getTime() - config.WEEK_IN_MILISECONDS + config.TIME_ZONE);
-    const last_week = new Date (date.getTime() - (config.WEEK_IN_MILISECONDS * 2) + config.TIME_ZONE) ;
+    const current_week = new Date( date.getTime() - config.WEEK_IN_MILISECONDS );
+    const last_week = new Date (date.getTime() - (config.WEEK_IN_MILISECONDS * 2) ) ;
 
     //se obtiene la cantidad de alertas de la semana actual y la semana anterior
     const quantityAlertCurrentWeek = await Alert.find({ "id_company": id_company , "createdAt": {"$gte": current_week}} ).count();

--- a/Backend/src/routes/Alert/alert.controller.ts
+++ b/Backend/src/routes/Alert/alert.controller.ts
@@ -115,7 +115,7 @@ export const quantityAlerts: RequestHandler = async (req, res) => {
     
     const date = new Date(); //fecha actual
 
-    //se definen los tiempos de inicio de la semana actual y la anterior + las 3 hrs de la zona horaria
+    //se definen los tiempos de inicio de la semana actual y la anterior
     const current_week = new Date( date.getTime() - config.WEEK_IN_MILISECONDS );
     const last_week = new Date (date.getTime() - (config.WEEK_IN_MILISECONDS * 2) ) ;
 

--- a/Backend/src/routes/Reading/reading.controller.ts
+++ b/Backend/src/routes/Reading/reading.controller.ts
@@ -142,7 +142,6 @@ export const readingSensorGraphic: RequestHandler = async (req, res) => {
     if ( !sensorFound )
         return res.status(404).send({ success: false, data:{}, message: 'ERROR: El sensor ingresado no existe en el sistema.' });
 
-    //Se compensa la zona horaria
     const current_date = new Date();
     const date:any = [];
 

--- a/Backend/src/routes/Reading/reading.controller.ts
+++ b/Backend/src/routes/Reading/reading.controller.ts
@@ -143,7 +143,7 @@ export const readingSensorGraphic: RequestHandler = async (req, res) => {
         return res.status(404).send({ success: false, data:{}, message: 'ERROR: El sensor ingresado no existe en el sistema.' });
 
     //Se compensa la zona horaria
-    const current_date = new Date(new Date().getTime() + config.TIME_ZONE);
+    const current_date = new Date();
     const date:any = [];
 
     //si son solicitadas las lecturas de los ultimos 30 días

--- a/Backend/src/routes/Reading/reading.controller.ts
+++ b/Backend/src/routes/Reading/reading.controller.ts
@@ -3,6 +3,7 @@ import { Types } from 'mongoose';
 import Reading from './reading.model'
 import Sensor from '../Sensor/sensor.model';
 import Station from '../Station/station.model';
+import Company from '../Company/company.model';
 import { createAlert } from '../Alert/alert.controller';
 import { signToken } from "../../middlewares/jwt";
 import config from '../../config/config'
@@ -228,4 +229,22 @@ export const readingSensorGraphic: RequestHandler = async (req, res) => {
     }
 
     return res.status(200).send({ success: true, data:{'name_sensor': sensorFound.name, 'time': date, 'readings': values}, message: "Lecturas encontradas con éxito."});
+}
+
+export const companyReadings: RequestHandler = async (req, res) => {
+    const id_company = req.params.id_company;
+
+    //se valida el id_company
+    if ( !Types.ObjectId.isValid( id_company) )
+    return res.status(400).send({ success: false, data:{}, message: 'ERROR: El id_sensor ingresado no es válido.' });
+
+    const companyFound = await Company.findById( id_company );
+
+    //Se valida la existencia de la compañia ingresada
+    if ( !companyFound )
+        return res.status(404).send({ success: false, data:{}, message: 'ERROR: La compañia ingresada no existe en el sistema.' });
+
+    const date = new Date( new Date() + );
+
+
 }

--- a/Backend/src/routes/Reading/reading.controller.ts
+++ b/Backend/src/routes/Reading/reading.controller.ts
@@ -256,7 +256,7 @@ export const companyReadings: RequestHandler = async (req, res) => {
     if ( !companyFound )
         return res.status(404).send({ success: false, data:{}, message: 'ERROR: La compañia ingresada no existe en el sistema.' });
 
-    //se captura la fecha actual compensando la zona horaria
+    //se captura la fecha actual 
     const current_week = new Date();
 
     //se calcula la semana anterior en función de la fecha actual

--- a/Backend/src/routes/Reading/reading.controller.ts
+++ b/Backend/src/routes/Reading/reading.controller.ts
@@ -237,6 +237,12 @@ export const readingSensorGraphic: RequestHandler = async (req, res) => {
     return res.status(200).send({ success: true, data:{'name_sensor': sensorFound.name, 'time': date, 'readings': values}, message: "Lecturas encontradas con éxito."});
 }
 
+/**
+ * Función encargada de obtener la cantidad de lecturas asociadas a una compañia
+ * @route Get '/readings/week/:id_company'
+ * @param req Request de la petición, se espera que tenga el id de la Compañia
+ * @param res Response, retorna un object con succes: true, data: {}, message: "String" de las lecturas asociadas a la compañia.
+ */
 export const companyReadings: RequestHandler = async (req, res) => {
     const id_company = req.params.id_company;
 
@@ -250,7 +256,14 @@ export const companyReadings: RequestHandler = async (req, res) => {
     if ( !companyFound )
         return res.status(404).send({ success: false, data:{}, message: 'ERROR: La compañia ingresada no existe en el sistema.' });
 
-    const date = new Date( new Date() + );
+    //se captura la fecha actual compensando la zona horaria
+    const current_week = new Date();
 
+    //se calcula la semana anterior en función de la fecha actual
+    const last_week = new Date( current_week.getTime() - config.WEEK_IN_MILISECONDS);
 
+    //se obtienen las lecturas de la ultima semana
+    const quantity_readings = await Reading.find({ "id_company": id_company, "createdAt": {"$gte": last_week} }).count(); 
+
+    return res.status(200).send({ success: true, data:{ "quantity": quantity_readings }, message: "Lecturas encontradas con éxito."});
 }

--- a/Backend/src/routes/Reading/reading.routes.ts
+++ b/Backend/src/routes/Reading/reading.routes.ts
@@ -13,4 +13,7 @@ router.get('/readings/:id_sensor', readingCtrl.sensorReadings);
 // Obtener lista de lecturas asociadas a un sensor, filtradas por 30 días, 3 meses y 6 meses
 router.post('/readings/graphic/:id_sensor', readingCtrl.readingSensorGraphic);
 
+//Obtener cantidad de lecturas de la ultima semana asociadas a una compañia
+router.get('/readings/week/:id_company', readingCtrl.companyReadings);
+
 export default router;

--- a/Backend/src/routes/Sensor/sensor.controller.ts
+++ b/Backend/src/routes/Sensor/sensor.controller.ts
@@ -279,7 +279,7 @@ export const readPanelStations: RequestHandler = async (req, res) => {
             value = reading.value;
         }
         
-        //se arama el objeto estación
+        //se arma el objeto estación
         const stationPanel = {
             id_station: station._id,
             name_station: station.name,

--- a/Backend/src/routes/Station/station.controller.ts
+++ b/Backend/src/routes/Station/station.controller.ts
@@ -254,7 +254,7 @@ export const deleteStation: RequestHandler = async (req, res) => {
         return res.status(404).send({ success: false, data:{}, message: 'ERROR: La compañia ingresada no existe en el sistema.' });
     
     //se compenza la zona horaria
-    const current_date = new Date( new Date().getTime() + config.TIME_ZONE);
+    const current_date = new Date();
     const date:any = [];
 
     //si son solicitadas las lecturas de los ultimos 30 días

--- a/Backend/src/routes/Station/station.controller.ts
+++ b/Backend/src/routes/Station/station.controller.ts
@@ -217,6 +217,7 @@ export const deleteStation: RequestHandler = async (req, res) => {
             name_station: station.name,
             sensor: {
                 id_sensor: sensors[i]._id, 
+                name: sensors[i].name,
                 min_config: sensors[i].min_config,
                 max_config: sensors[i].max_config,
                 type: sensors[i].type,


### PR DESCRIPTION
Se agrega el endpoint companyReadings, en la ruta http://localhost:4000/readings/week/:id_company, que recibe el id_company por params y retorna un objecto con la cantidad de lecturas de la ultima semana. 
![imagen](https://user-images.githubusercontent.com/39105967/155794891-cf094dea-da2b-49a0-b7bd-7cb56fa42ba7.png)

Además, se agregó una variable name para un return solicitado por el front y se solucionaron unas incongruencias de un Pr anterior con respecto a los tipo Date().