### PR TITLE
ADD: readCustomAlertTime

### DIFF
--- a/Backend/src/routes/Sensor/sensor.controller.ts
+++ b/Backend/src/routes/Sensor/sensor.controller.ts
@@ -390,3 +390,28 @@ export const customAlertTime: RequestHandler = async (req, res) => {
 
     return res.status(200).send( { success: true, data:{}, message: 'Custom_alert actualizada de manera correcta.'});
 }
+
+/**
+ * Función encargada obtener el valor boleano de custom_alert y retornarlo al front con el valor de alert_time en minutos
+ * @route Get '/sensor/custom_alert/value/:id'
+ * @param req Request de la petición, se espera que tenga el id del sensor
+ * @param res Response, retorna un object con succes: true, data: { }, message: "String" del custom_alert si todo sale bien
+ */
+export const readCustomAlertTime: RequestHandler = async (req, res) => {
+    const _idSensor = req.params.id;
+
+    //se valida el _id ingresado del sensor
+    if ( !Types.ObjectId.isValid( _idSensor ) )
+        return res.status(400).send({ success: false, data:{}, message: 'ERROR: El id ingresado no es válido.' });
+
+    const sensorFound = await Sensor.findById( _idSensor );
+
+    //se valida la existencia del sensor en el sistema
+    if ( !sensorFound )
+        return res.status(404).send({ success: false, data:{}, message: 'ERROR: El sensor ingresado no existe en el sistema.' });
+
+    return res.status(200).send( { success: true, data:{
+        custom_alert: sensorFound.custom_alert, 
+        time: sensorFound.alert_time 
+    }, message: 'Custom_alert econtrado' });
+}

--- a/Backend/src/routes/Sensor/sensor.routes.ts
+++ b/Backend/src/routes/Sensor/sensor.routes.ts
@@ -30,4 +30,7 @@ router.get('/panel/sensors/:id_company', sensorCtrl.sensorsON);
 // Modificar el valor de custom_alert (apagándolo)
 router.get('/sensor/custom_alert/:id', sensorCtrl.customAlertTime);
 
+//Obtener un true or false si custom_alert está activo, en caso de true obtener su valor en minutos
+router.get('/sensor/custom_alert/value/:id', sensorCtrl.readCustomAlertTime);
+
 export default router;


### PR DESCRIPTION
Se agrega el endpoint en la ruta http://localhost:4000/sensor/custom_alert/value/:id 
El cual obtiene el valor de custom_alert (true o false) y el valor del valor (valga la redundancia) del alert_time (en minutos). El cual vendría siendo el tiempo de alertas definidas por el usuario.
Retorna el siguiente objeto:
![imagen](https://user-images.githubusercontent.com/39105967/156792807-ae29bd27-25b1-434d-a942-0aa592c69817.png)
